### PR TITLE
UI/UX improvements: info modal, Social/Hardware filters, version badges, configure wiring, New filter, date_added, clipboard error states

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Stop downloading massive ZIP files.** Install Pwnagotchi plugins surgically—one file at a time.
 
-[![CLI Version](https://img.shields.io/badge/CLI-v2.5-green)](https://github.com/MrBumChinz/pwnagotchi-store) [![UI Version](https://img.shields.io/badge/Web_UI-v1.0-blue)](https://github.com/MrBumChinz/pwnagotchi-store) [![Gallery](https://img.shields.io/badge/Gallery-Live-orange)](https://pwnstore.org/) [![License](https://img.shields.io/badge/license-GPL3-red)](LICENSE)
+[![CLI Version](https://img.shields.io/badge/CLI-v2.5-green)](https://github.com/wpa-2/pwnagotchi-store) [![UI Version](https://img.shields.io/badge/Web_UI-v1.0-blue)](https://github.com/wpa-2/pwnagotchi-store) [![Gallery](https://img.shields.io/badge/Gallery-Live-orange)](https://pwnstore.org/) [![License](https://img.shields.io/badge/license-GPL3-red)](LICENSE)
 
 ---
 
@@ -10,7 +10,7 @@
 
 SSH into your Pwnagotchi and run:
 ```bash
-sudo wget -O /usr/local/bin/pwnstore https://raw.githubusercontent.com/MrBumChinz/pwnagotchi-store/main/pwnstore.py && sudo chmod +x /usr/local/bin/pwnstore
+sudo wget -O /usr/local/bin/pwnstore https://raw.githubusercontent.com/wpa-2/pwnagotchi-store/main/pwnstore.py && sudo chmod +x /usr/local/bin/pwnstore
 ```
 
 Then browse and install plugins:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Stop downloading massive ZIP files.** Install Pwnagotchi plugins surgically—one file at a time.
 
-[![CLI Version](https://img.shields.io/badge/CLI-v2.5-green)](https://github.com/wpa-2/pwnagotchi-store) [![UI Version](https://img.shields.io/badge/Web_UI-v1.0-blue)](https://github.com/wpa-2/pwnagotchi-store) [![Gallery](https://img.shields.io/badge/Gallery-Live-orange)](https://pwnstore.org/) [![License](https://img.shields.io/badge/license-GPL3-red)](LICENSE)
+[![CLI Version](https://img.shields.io/badge/CLI-v2.5-green)](https://github.com/MrBumChinz/pwnagotchi-store) [![UI Version](https://img.shields.io/badge/Web_UI-v1.0-blue)](https://github.com/MrBumChinz/pwnagotchi-store) [![Gallery](https://img.shields.io/badge/Gallery-Live-orange)](https://pwnstore.org/) [![License](https://img.shields.io/badge/license-GPL3-red)](LICENSE)
 
 ---
 
@@ -10,7 +10,7 @@
 
 SSH into your Pwnagotchi and run:
 ```bash
-sudo wget -O /usr/local/bin/pwnstore https://raw.githubusercontent.com/wpa-2/pwnagotchi-store/main/pwnstore.py && sudo chmod +x /usr/local/bin/pwnstore
+sudo wget -O /usr/local/bin/pwnstore https://raw.githubusercontent.com/MrBumChinz/pwnagotchi-store/main/pwnstore.py && sudo chmod +x /usr/local/bin/pwnstore
 ```
 
 Then browse and install plugins:

--- a/builder.py
+++ b/builder.py
@@ -7,6 +7,7 @@ import zipfile
 import os
 import logging
 from collections import defaultdict
+from datetime import date
 
 # --- CONFIGURATION ---
 INPUT_FILE = "repos.txt"
@@ -57,23 +58,26 @@ def parse_python_content(code, filename, origin_url, internal_path=None):
 
         data['version'] = version_match.group(1) if version_match else "0.0.1"
         data['author'] = author_match.group(1) if author_match else "Unknown"
-        data['description'] = desc_match.group(2).strip() if desc_match else "No description provided."
+        data['description'] = desc_match.group(2).strip() if desc_match else ""
+        
+        # Skip plugins with no description — they pollute the registry
+        if not data['description']:
+            logging.debug(f"    [-] {filename.split('/')[-1]} skipped — no __description__")
+            return None
         
         # Determine category
         data['category'] = detect_category(filename.replace(".py", ""), data['description'], code)
 
-        # Only return data if we found enough metadata
-        if data['description'] != "No description provided." or data['version'] != "0.0.1":
-            return {
-                "name": filename.replace(".py", ""),
-                "version": data['version'],
-                "description": data['description'],
-                "author": data['author'],
-                "category": data['category'],
-                "origin_type": "zip" if internal_path else "single",
-                "download_url": origin_url,
-                "path_inside_zip": internal_path
-            }
+        return {
+            "name": filename.replace(".py", ""),
+            "version": data['version'],
+            "description": data['description'],
+            "author": data['author'],
+            "category": data['category'],
+            "origin_type": "zip" if internal_path else "single",
+            "download_url": origin_url,
+            "path_inside_zip": internal_path
+        }
         
     except Exception as e:
         # Silently fail here (pass) to prevent the build process from crashing 
@@ -109,6 +113,18 @@ def process_zip_url(url):
 def main():
     print("--- PwnStore Builder v1.2 Starting ---")
     master_list = []
+
+    # Load existing date_added values so we don't overwrite them on re-runs
+    existing_dates = {}
+    if os.path.exists(OUTPUT_FILE):
+        try:
+            with open(OUTPUT_FILE) as f:
+                for p in json.load(f):
+                    if p.get('date_added'):
+                        existing_dates[p['name'].lower()] = p['date_added']
+        except Exception:
+            pass
+    today = date.today().isoformat()
     
     if not os.path.exists(INPUT_FILE):
         logging.error(f"Error: {INPUT_FILE} not found.")
@@ -142,6 +158,10 @@ def main():
             
     # Sort the final list alphabetically by name
     sorted_plugins = sorted(final_plugins.values(), key=lambda p: p['name'].lower())
+
+    # Stamp date_added: preserve existing dates, assign today for new entries
+    for p in sorted_plugins:
+        p['date_added'] = existing_dates.get(p['name'].lower(), today)
 
     with open(OUTPUT_FILE, "w") as f:
         json.dump(sorted_plugins, f, indent=2)

--- a/index.html
+++ b/index.html
@@ -255,7 +255,7 @@
             <div class="install-action" id="install-btn-text">[COPY]</div>
         </div>
         <div class="contribute-link">
-            Want to add your plugin? <a href="https://github.com/MrBumChinz/pwnagotchi-store" target="_blank">Submit a PR</a>
+            Want to add your plugin? <a href="https://github.com/wpa-2/pwnagotchi-store" target="_blank">Submit a PR</a>
         </div>
     </div>
 
@@ -387,7 +387,7 @@
         
         // HEADER INSTALL COPY
         function copyInstallCmd() {
-            const text = "sudo wget -O /usr/local/bin/pwnstore https://raw.githubusercontent.com/MrBumChinz/pwnagotchi-store/main/pwnstore.py && sudo chmod +x /usr/local/bin/pwnstore";
+            const text = "sudo wget -O /usr/local/bin/pwnstore https://raw.githubusercontent.com/wpa-2/pwnagotchi-store/main/pwnstore.py && sudo chmod +x /usr/local/bin/pwnstore";
             const btn = document.getElementById('install-btn-text');
             
             if (navigator.clipboard && window.isSecureContext) {

--- a/index.html
+++ b/index.html
@@ -261,6 +261,7 @@
 
     <div class="filters">
         <button class="filter-btn active" onclick="setCategory('All')">All</button>
+        <button class="filter-btn" onclick="setCategory('New')" style="border-color:#0a0;">New</button>
         <button class="filter-btn" onclick="setCategory('Display')">Display</button>
         <button class="filter-btn" onclick="setCategory('GPS')">GPS</button>
         <button class="filter-btn" onclick="setCategory('Social')">Social</button>
@@ -312,6 +313,8 @@
         function renderPlugins(list) {
             const grid = document.getElementById('plugin-grid');
             grid.innerHTML = "";
+            const thirtyDaysAgo = new Date();
+            thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
             list.forEach(p => {
                 let cleanAuthor = p.author.replace(/<[^>]*>/g, "").trim().replace(/[\w\.-]+@[\w\.-]+/g, "").trim().replace(/^[0-9]+\+/, "").trim();
                 if(cleanAuthor.length > 20) cleanAuthor = cleanAuthor.substring(0, 18) + "...";
@@ -321,6 +324,7 @@
                 if(repoUrl.includes('/archive/')) repoUrl = repoUrl.split('/archive/')[0];
                 else if(repoUrl.includes('raw.githubusercontent.com')) repoUrl = repoUrl.replace('raw.githubusercontent.com', 'github.com').replace('/main/', '/blob/main/').replace('/master/', '/blob/master/');
 
+                const isNew = p.date_added && new Date(p.date_added) >= thirtyDaysAgo;
                 const card = document.createElement('div');
                 card.className = 'card';
                 card.innerHTML = `
@@ -331,6 +335,7 @@
                     <div class="meta-row">
                         <div class="author">by ${cleanAuthor}</div>
                         <div class="badges">
+                            ${isNew ? '<span class="badge" style="background:#0a3a0a; color:#0f0; border:1px solid #0f0;">NEW</span>' : ''}
                             <span class="badge cat">${p.category || 'General'}</span>
                             <span class="badge">v${p.version}</span>
                         </div>
@@ -346,8 +351,13 @@
 
         function filterPlugins() {
             const term = document.getElementById('search').value.toLowerCase();
+            const thirtyDaysAgo = new Date();
+            thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
             const filtered = plugins.filter(p => {
                 const matchSearch = p.name.toLowerCase().includes(term) || p.description.toLowerCase().includes(term);
+                if (currentCategory === 'New') {
+                    return matchSearch && p.date_added && new Date(p.date_added) >= thirtyDaysAgo;
+                }
                 const matchCat = currentCategory === 'All' || p.category === currentCategory;
                 return matchSearch && matchCat;
             });
@@ -390,39 +400,44 @@
             const text = "sudo wget -O /usr/local/bin/pwnstore https://raw.githubusercontent.com/wpa-2/pwnagotchi-store/main/pwnstore.py && sudo chmod +x /usr/local/bin/pwnstore";
             const btn = document.getElementById('install-btn-text');
             
+            const onSuccess = () => { btn.innerText = "[COPIED!]"; setTimeout(() => btn.innerText = "[COPY]", 2000); };
+            const onFail = () => { btn.innerText = "[COPY FAILED]"; setTimeout(() => btn.innerText = "[COPY]", 2500); };
+            
             if (navigator.clipboard && window.isSecureContext) {
-                navigator.clipboard.writeText(text);
+                navigator.clipboard.writeText(text).then(onSuccess).catch(onFail);
             } else {
                 const ta = document.createElement("textarea");
                 ta.value = text; ta.style.position="fixed"; ta.style.left="-9999px";
-                document.body.appendChild(ta); ta.select(); document.execCommand('copy');
+                document.body.appendChild(ta); ta.select();
+                const ok = document.execCommand('copy');
                 document.body.removeChild(ta);
+                ok ? onSuccess() : onFail();
             }
-            
-            const originalText = btn.innerText;
-            btn.innerText = "[COPIED!]";
-            setTimeout(() => btn.innerText = originalText, 2000);
         }
 
         // MODAL COPY
         function copyText(element) {
             const text = element.innerText;
-            element.style.borderColor = "var(--accent)";
-            element.style.color = "#fff";
+            
+            const onSuccess = () => {
+                element.style.borderColor = "var(--accent)"; element.style.color = "#fff";
+                setTimeout(() => { element.style.borderColor = "#333"; element.style.color = "#ccc"; }, 1500);
+            };
+            const onFail = () => {
+                element.style.borderColor = "var(--danger)"; element.style.color = "var(--danger)";
+                setTimeout(() => { element.style.borderColor = "#333"; element.style.color = "#ccc"; }, 2000);
+            };
             
             if (navigator.clipboard && window.isSecureContext) {
-                navigator.clipboard.writeText(text);
+                navigator.clipboard.writeText(text).then(onSuccess).catch(onFail);
             } else {
                 const ta = document.createElement("textarea");
                 ta.value = text; ta.style.position="fixed"; ta.style.left="-9999px";
-                document.body.appendChild(ta); ta.select(); document.execCommand('copy');
+                document.body.appendChild(ta); ta.select();
+                const ok = document.execCommand('copy');
                 document.body.removeChild(ta);
+                ok ? onSuccess() : onFail();
             }
-
-            setTimeout(() => {
-                element.style.borderColor = "#333";
-                element.style.color = "#ccc";
-            }, 300);
         }
 
         window.onclick = e => { if(e.target == modal) closeModal(); }

--- a/index.html
+++ b/index.html
@@ -255,7 +255,7 @@
             <div class="install-action" id="install-btn-text">[COPY]</div>
         </div>
         <div class="contribute-link">
-            Want to add your plugin? <a href="https://github.com/wpa-2/pwnagotchi-store" target="_blank">Submit a PR</a>
+            Want to add your plugin? <a href="https://github.com/MrBumChinz/pwnagotchi-store" target="_blank">Submit a PR</a>
         </div>
     </div>
 
@@ -387,7 +387,7 @@
         
         // HEADER INSTALL COPY
         function copyInstallCmd() {
-            const text = "sudo wget -O /usr/local/bin/pwnstore https://raw.githubusercontent.com/wpa-2/pwnagotchi-store/main/pwnstore.py && sudo chmod +x /usr/local/bin/pwnstore";
+            const text = "sudo wget -O /usr/local/bin/pwnstore https://raw.githubusercontent.com/MrBumChinz/pwnagotchi-store/main/pwnstore.py && sudo chmod +x /usr/local/bin/pwnstore";
             const btn = document.getElementById('install-btn-text');
             
             if (navigator.clipboard && window.isSecureContext) {

--- a/pwnstore.py
+++ b/pwnstore.py
@@ -17,7 +17,7 @@ import shutil
 import re
 
 # --- CONFIGURATION ---
-DEFAULT_REGISTRY = "https://raw.githubusercontent.com/wpa-2/pwnagotchi-store/main/plugins.json"
+DEFAULT_REGISTRY = "https://raw.githubusercontent.com/MrBumChinz/pwnagotchi-store/main/plugins.json"
 
 # Fallback if config.toml has no custom_plugins entry
 DEFAULT_CUSTOM_PLUGIN_DIR = "/etc/pwnagotchi/custom-plugins/"
@@ -376,7 +376,7 @@ def show_detailed_help():
     print(f"  {CYAN}pwnstore info discord{RESET}            View discord plugin details\n")
     
     print(f"Need help?")
-    print(f"  https://github.com/wpa-2/pwnagotchi-store")
+    print(f"  https://github.com/MrBumChinz/pwnagotchi-store")
     print(f"  https://t.me/Pwnagotchi_UK_Chat/\n")
 
 def show_minimal_help():

--- a/pwnstore.py
+++ b/pwnstore.py
@@ -17,7 +17,7 @@ import shutil
 import re
 
 # --- CONFIGURATION ---
-DEFAULT_REGISTRY = "https://raw.githubusercontent.com/MrBumChinz/pwnagotchi-store/main/plugins.json"
+DEFAULT_REGISTRY = "https://raw.githubusercontent.com/wpa-2/pwnagotchi-store/main/plugins.json"
 
 # Fallback if config.toml has no custom_plugins entry
 DEFAULT_CUSTOM_PLUGIN_DIR = "/etc/pwnagotchi/custom-plugins/"
@@ -376,7 +376,7 @@ def show_detailed_help():
     print(f"  {CYAN}pwnstore info discord{RESET}            View discord plugin details\n")
     
     print(f"Need help?")
-    print(f"  https://github.com/MrBumChinz/pwnagotchi-store")
+    print(f"  https://github.com/wpa-2/pwnagotchi-store")
     print(f"  https://t.me/Pwnagotchi_UK_Chat/\n")
 
 def show_minimal_help():

--- a/pwnstore.py
+++ b/pwnstore.py
@@ -144,24 +144,33 @@ def list_plugins(args):
     print("-" * 80)
 
 def list_sources(args):
-    print(f"[*] Analyzing repository sources...")
+    print(f"[*] Fetching registry...")
     registry = fetch_registry()
-    sources = {} 
+    sources = {}
     for p in registry:
         url = p.get('download_url', '')
-        repo_name = "Unknown Source"
+        repo_key = "other"
+        repo_display = "Other/Local"
         if 'github.com' in url or 'githubusercontent.com' in url:
             parts = url.split('/')
-            try: repo_name = f"github.com/{parts[3]}/{parts[4]}"
-            except: repo_name = url[:40]
-        else: repo_name = "Other/Local"
-        sources[repo_name] = sources.get(repo_name, 0) + 1
-    print(f"\n{'REPOSITORY / SOURCE':<50} | {'PLUGINS'}")
-    print("-" * 65)
-    for source, count in sorted(sources.items()):
-        print(f"{source:<50} | {count}")
-    print("-" * 65)
-    print(f"Total indexed: {len(registry)}\n")
+            try:
+                user, repo = parts[3], parts[4]
+                repo_key = f"{user}/{repo}"
+                repo_display = f"https://github.com/{user}/{repo}"
+            except:
+                repo_key = url[:50]
+                repo_display = repo_key
+        if repo_key not in sources:
+            sources[repo_key] = {'display': repo_display, 'count': 0}
+        sources[repo_key]['count'] += 1
+
+    sorted_sources = sorted(sources.values(), key=lambda x: x['count'], reverse=True)
+    print(f"\n{'REPOSITORY':<55} | {'PLUGINS'}")
+    print("-" * 70)
+    for s in sorted_sources:
+        print(f"{s['display']:<55} | {s['count']}")
+    print("-" * 70)
+    print(f"Total repos: {len(sources)}  |  Total plugins indexed: {len(registry)}\n")
 
 def search_plugins(args):
     registry = fetch_registry()

--- a/pwnstore_ui.py
+++ b/pwnstore_ui.py
@@ -34,7 +34,7 @@ class PwnStoreUI(plugins.Plugin):
 
     def __init__(self):
         self.ready = False
-        self.store_url = "https://raw.githubusercontent.com/wpa-2/pwnagotchi-store/main/plugins.json"
+        self.store_url = "https://raw.githubusercontent.com/MrBumChinz/pwnagotchi-store/main/plugins.json"
         
     def on_loaded(self):
         logging.info("[pwnstore_ui] Plugin loaded")

--- a/pwnstore_ui.py
+++ b/pwnstore_ui.py
@@ -28,7 +28,7 @@ except ImportError:
 
 class PwnStoreUI(plugins.Plugin):
     __author__ = 'WPA2'
-    __version__ = '1.2.7'
+    __version__ = '3.3.2'
     __license__ = 'GPL3'
     __description__ = 'Plugin store with web interface for browsing and installing plugins'
 
@@ -156,6 +156,8 @@ class PwnStoreUI(plugins.Plugin):
         <button class="filter-btn active" data-category="all">All</button>
         <button class="filter-btn" data-category="Display">Display</button>
         <button class="filter-btn" data-category="GPS">GPS</button>
+        <button class="filter-btn" data-category="Social">Social</button>
+        <button class="filter-btn" data-category="Hardware">Hardware</button>
         <button class="filter-btn" data-category="Attack">Attack</button>
         <button class="filter-btn" data-category="System">System</button>
     </div>
@@ -163,7 +165,7 @@ class PwnStoreUI(plugins.Plugin):
     <div class="stats"><span id="pluginCount">Loading plugins...</span></div>
     <div id="pluginsContainer" class="plugins-grid"></div>
 
-    <div class="footer">Built by <strong>WPA2</strong> • v3.2.6 • <a href="https://github.com/wpa-2/pwnagotchi-store" style="color: #0f0;">GitHub</a></div>
+    <div class="footer">Built by <strong>WPA2</strong> • v3.3.2 • <a href="https://github.com/wpa-2/pwnagotchi-store" style="color: #0f0;">GitHub</a></div>
 
     <script>
         let allPlugins = [];
@@ -208,13 +210,13 @@ class PwnStoreUI(plugins.Plugin):
                 const search = !searchTerm || p.name.toLowerCase().includes(searchTerm) || p.description.toLowerCase().includes(searchTerm);
                 return cat && search;
             });
-            document.getElementById('pluginCount').textContent = `Showing ${filtered.length} plugins`;
+            document.getElementById('pluginCount').textContent = `Showing ${filtered.length} of ${allPlugins.length} plugins`;
             container.innerHTML = filtered.map(p => {
                 const isInst = installedPlugins.includes(p.name);
                 return `
                     <div class="plugin-card" data-name="${p.name}">
                         ${isInst ? '<span class="status-badge installed">✓ INSTALLED</span>' : ''}
-                        <div class="plugin-header"><div class="plugin-name">${p.name}</div></div>
+                        <div class="plugin-header"><div class="plugin-name">${p.name}</div><span class="badge" style="font-size:10px; padding: 2px 6px; margin-left:auto; flex-shrink:0;">v${p.version || '?'}</span></div>
                         <div class="plugin-author">by ${p.author}</div>
                         <div class="plugin-description">${p.description || ''}</div>
                         <div class="plugin-actions">
@@ -260,21 +262,45 @@ class PwnStoreUI(plugins.Plugin):
                 <div class="config-modal">
                     <div class="config-header">
                         <h2>⚙️ ${name} installed!</h2>
-                        <p>Configuration may be required</p>
+                        <p>Enable the plugin in your config to activate it</p>
                     </div>
-                    <div style="margin: 20px 0; text-align: center;">
-                        <p style="margin-bottom: 15px;">Edit <code>/etc/pwnagotchi/config.toml</code> to configure this plugin.</p>
-                        ${repoUrl ? `<a href="${repoUrl}" target="_blank" class="config-btn" style="display: inline-block; text-decoration: none;">📖 View Setup Instructions</a>` : ''}
-                        <button type="button" class="config-btn config-btn-secondary" onclick="document.getElementById('configOverlay').remove()">Close</button>
+                    <div style="margin: 20px 0;">
+                        <button type="button" id="btn-enable-plugin" class="config-btn">✅ Enable in config.toml</button>
+                        ${repoUrl ? `<a href="${repoUrl}" target="_blank" class="config-btn" style="display: block; text-decoration: none; text-align: center; margin-top: 8px;">📖 View Setup Instructions</a>` : ''}
+                        <button type="button" class="config-btn config-btn-secondary" onclick="document.getElementById('configOverlay').remove()" style="margin-top: 8px;">Close</button>
                     </div>
                 </div>
             `;
+            overlay.querySelector('#btn-enable-plugin').onclick = async () => {
+                const btn = overlay.querySelector('#btn-enable-plugin');
+                btn.textContent = 'Saving...'; btn.disabled = true;
+                try {
+                    const res = await apiRequest('/plugins/pwnstore_ui/api/configure', {
+                        method: 'POST', body: JSON.stringify({ plugin: name, config: { enabled: true } })
+                    });
+                    if (res.success) {
+                        btn.textContent = '✅ Enabled!';
+                        showMessage(`${name} enabled in config.toml. Restart to activate.`, 'success');
+                    } else {
+                        btn.textContent = '❌ Failed — edit manually'; btn.disabled = false;
+                    }
+                } catch (e) { btn.textContent = '❌ Error'; btn.disabled = false; }
+            };
             document.body.appendChild(overlay);
         }
 
         function showInfo(name) {
             const p = allPlugins.find(x => x.name === name);
-            alert(`Plugin: ${p.name}\\nAuthor: ${p.author}\\n\\n${p.description}`);
+            if (!p) return;
+            document.getElementById('info-modal-name').textContent = p.name + ' v' + (p.version || '?');
+            document.getElementById('info-modal-author').textContent = 'by ' + (p.author || 'Unknown');
+            document.getElementById('info-modal-desc').textContent = p.description || 'No description available.';
+            const repoEl = document.getElementById('info-modal-repo');
+            let repoUrl = p.download_url || '';
+            if (repoUrl.includes('/archive/')) repoUrl = repoUrl.split('/archive/')[0];
+            if (repoUrl) { repoEl.href = repoUrl; repoEl.style.display = 'block'; }
+            else { repoEl.style.display = 'none'; }
+            document.getElementById('info-overlay').style.display = 'flex';
         }
 
         function showMessage(text, type) {
@@ -296,6 +322,18 @@ class PwnStoreUI(plugins.Plugin):
         });
         loadData();
     </script>
+    <div class="config-overlay" id="info-overlay" style="display:none;">
+        <div class="config-modal">
+            <div class="config-header">
+                <h2 id="info-modal-name" style="font-size:18px;"></h2>
+                <p id="info-modal-author" style="font-size:12px; color:#0a0; margin-top:4px;"></p>
+            </div>
+            <div id="info-modal-desc" style="margin: 15px 0; font-size: 13px; color: #ccc; line-height: 1.6;"></div>
+            <a id="info-modal-repo" href="#" target="_blank" class="config-btn" style="display:none; text-decoration:none; text-align:center; margin-bottom:8px; display:block;">📂 View Source Repo</a>
+            <button class="config-btn config-btn-secondary" onclick="document.getElementById('info-overlay').style.display='none'">Close</button>
+        </div>
+    </div>
+
 </body>
 </html>
         """

--- a/pwnstore_ui.py
+++ b/pwnstore_ui.py
@@ -34,7 +34,7 @@ class PwnStoreUI(plugins.Plugin):
 
     def __init__(self):
         self.ready = False
-        self.store_url = "https://raw.githubusercontent.com/MrBumChinz/pwnagotchi-store/main/plugins.json"
+        self.store_url = "https://raw.githubusercontent.com/wpa-2/pwnagotchi-store/main/plugins.json"
         
     def on_loaded(self):
         logging.info("[pwnstore_ui] Plugin loaded")

--- a/repos.txt
+++ b/repos.txt
@@ -9,6 +9,12 @@ https://github.com/unitMeasure/pwn-plugins/archive/main.zip
 https://github.com/wsvdmeer/pwnagotchi-plugins/archive/main.zip
 https://raw.githubusercontent.com/wpa-2/pwnagotchi-store/main/pwnstore_ui.py
 
+<<<<<<< HEAD
 https://github.com/MrBumChinz/pwnrank/archive/master.zip
 https://github.com/MrBumChinz/community-quickdic
 https://github.com/MrBumChinz/Evil-Twin
+=======
+https://github.com/MrBumChinz/pwnrank
+https://github.com/MrBumChinz/community-quickdic/archive/main.zip
+https://github.com/MrBumChinz/Evil-Twin/archive/master.zip
+>>>>>>> bf3e480 (Add: community_quickdic + evil_twin repos; fix upstream URLs to MrBumChinz fork)

--- a/repos.txt
+++ b/repos.txt
@@ -11,3 +11,4 @@ https://raw.githubusercontent.com/wpa-2/pwnagotchi-store/main/pwnstore_ui.py
 
 https://github.com/MrBumChinz/pwnrank/archive/master.zip
 https://github.com/MrBumChinz/community-quickdic
+https://github.com/MrBumChinz/Evil-Twin

--- a/repos.txt
+++ b/repos.txt
@@ -9,6 +9,4 @@ https://github.com/unitMeasure/pwn-plugins/archive/main.zip
 https://github.com/wsvdmeer/pwnagotchi-plugins/archive/main.zip
 https://raw.githubusercontent.com/wpa-2/pwnagotchi-store/main/pwnstore_ui.py
 
-https://github.com/MrBumChinz/pwnrank/archive/master.zip
-https://raw.githubusercontent.com/MrBumChinz/community-quickdic/refs/heads/main/community_quickdic.py
-https://github.com/MrBumChinz/Evil-Twin/archive/master.zip
+https://github.com/MrBumChinz/Pwnagotchi-Plugins/archive/main.zip


### PR DESCRIPTION
A set of improvements across index.html, pwnstore_ui.py, and builder.py:

**pwnstore_ui.py (Web UI)**
- Added Social + Hardware filter buttons (matching the gallery)
- Stats now shows "Showing X of Y plugins" (total count in header)
- Plugin cards show version badge
- Info button replaced browser alert() with a proper styled modal
- Post-install modal now has an "Enable in config.toml" button that calls api/configure and writes enabled = true automatically
- Version synced with is_safe_name() addition from upstream

**index.html (Gallery)**
- New filter button — shows plugins with date_added within last 30 days
- New badge on cards for recently added plugins
- Clipboard copy shows [COPY FAILED] in red on failure instead of silently doing nothing

**builder.py**
- Plugins with no __description__ are now skipped (no more "No description provided." entries)
- Every plugin entry gets a date_added field (preserved across re-runs, stamped today for new entries)

**pwnstore.py**
- pwnstore sources now sorts repos by plugin count and shows full GitHub URLs