### PR TITLE
Add PWMenu plugin source

### DIFF
--- a/repos.txt
+++ b/repos.txt
@@ -9,3 +9,4 @@ https://github.com/unitMeasure/pwn-plugins/archive/main.zip
 https://github.com/wsvdmeer/pwnagotchi-plugins/archive/main.zip
 https://raw.githubusercontent.com/wpa-2/pwnagotchi-store/main/pwnstore_ui.py
 https://github.com/CoderFX/pwnagotchi-plugins/archive/main.zip
+https://raw.githubusercontent.com/newfpv/pwmenu/main/A_pwmenu.py


### PR DESCRIPTION
## What changed

Adds the public PWMenu plugin source to `repos.txt`:

```text
https://raw.githubusercontent.com/newfpv/pwmenu/main/A_pwmenu.py
```

The registry can track the maintained `main` branch directly without vendoring a large plugin file into PwnStore.

## Plugin overview

PWMenu is a mobile-first Pwnagotchi capture and credential workflow manager. It provides:

- per-PCAP quality analysis and mode 22000 conversion
- exact BSSID-aware capture grouping and one-best-capture exports
- local `aircrack-ng` verification before manual passwords are accepted
- GPS and manual map placement for concrete handshakes
- integrated WPA-sec upload/result synchronization
- persistent OnlineHashCrack queueing and pre-queue deduplication
- optional OHC-only VLESS routing through a separately installed Xray binary
- integrated password display and background QuickDic functionality
- whitelist management, imports, exports, and confirmation-bound cleanup

## Compatibility and metadata

The raw source is publicly reachable and contains the required PwnStore metadata:

- `class A_pwmenu(plugins.Plugin)`
- `__author__ = 'NewFPV'`
- `__version__ = '1.3.7'`
- `__license__ = 'GPL3'`
- `__description__ = 'Ultimate Password Manager'`

The project is tested against the current Python 3.11 Pwnagotchi environment. Its own repository has 49 unit tests and green GitHub Actions checks.

## Security and dependencies

- Intended only for networks owned by the operator or explicitly authorized for auditing.
- API keys and optional VLESS credentials remain in the local root-owned Pwnagotchi configuration.
- The repository and published release contain no live service credentials.
- OHC is disabled until explicitly configured.
- Xray is optional, is not downloaded by the plugin, and is used only when an OHC VLESS URL is configured.
- `hcxpcapngtool` is recommended; `aircrack-ng` is required for password verification and QuickDic; `websockets` is optional for PwnDroid.

## Validation

- raw source URL returns HTTP 200
- source URL was not already present in `repos.txt`
- required plugin class and metadata were parsed successfully
- `git diff --check` passed
- this PR changes only one line in `repos.txt`

Project: https://github.com/newfpv/pwmenu

Documentation: https://neewfpv.com/wiki/pwmenu